### PR TITLE
[ejlee] modelAttribute 는 Setter 가 필요해서 게시물 데이터를 일시적으로 담는 RequestDto 생성

### DIFF
--- a/src/main/java/com/instagram_02/board/command/PostCommand.java
+++ b/src/main/java/com/instagram_02/board/command/PostCommand.java
@@ -1,0 +1,29 @@
+package com.instagram_02.board.command;
+
+import com.instagram_02.board.entity.Post;
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PostCommand {
+    private String title;
+    private String content;
+    private String userId;
+
+    public Post toEntity() {
+        return Post.builder()
+                .title(title)
+                .content(content)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/instagram_02/board/controller/PostController.java
+++ b/src/main/java/com/instagram_02/board/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.instagram_02.board.controller;
 
 
+import com.instagram_02.board.command.PostCommand;
 import com.instagram_02.board.entity.Post;
 import com.instagram_02.board.repository.PostRepository;
 import com.instagram_02.board.service.PostService;
@@ -34,13 +35,13 @@ public class PostController {
 
     @GetMapping("/create")
     public String createForm(Model model) {
-        model.addAttribute("post", new Post());
+        model.addAttribute("postCommand", new PostCommand());
         return "post/create";
     }
 
     @PostMapping("/create")
-    public String create(@ModelAttribute Post post) {
-        postService.save(post);
+    public String create(@ModelAttribute PostCommand postCommand) {
+        postService.save(postCommand.toEntity());
         return "redirect:/posts";
     }
 

--- a/src/main/java/com/instagram_02/board/entity/Post.java
+++ b/src/main/java/com/instagram_02/board/entity/Post.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 

--- a/src/main/resources/templates/post/create.html
+++ b/src/main/resources/templates/post/create.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <h1>새 게시물 작성</h1>
-<form th:action="@{'/posts/create'}" method="post" th:object="${post}">
+<form th:action="@{'/posts/create'}" method="post" th:object="${postCommand}">
   <label for="title">제목:</label>
   <input type="text" id="title" name="title" th:field="*{title}" required>
   <br>


### PR DESCRIPTION
## 개요
게시물 저장 시, Post 객체가 모두 Null 값이 들어감

## 원인
@ModelAttribute 가 붙어진 객체는 @Setter 가 필요함

## 작업상세
- Post 데이터를 담을 Request Dto 생성
- Dto 를 바로 JPA 를 통해 Insert하려면, 영속성 컨텍스트로 변경해줘야하기때문에 Dto 에 담겨있는 데이터를 toEntity() 를 통해 새로운 Entity 객체를 만들어내서 타입 변환함
- create.html 에서 Post -> PostCommand 로 변경